### PR TITLE
Add space in merge format for Github to autolink to the PR

### DIFF
--- a/git/merge-strategy.md
+++ b/git/merge-strategy.md
@@ -38,7 +38,7 @@ git merge --no-ff <branch-name> # forces a merge commit and will open commit pro
 When running the above command you will be prompted for a commit message for your merge. The commit message should be in the following format.
 
 ```
-<title of Kanbanery card or summary of feature> [<Task abbreviation>#<Kanbanery task number>] (<Source Control abbreviation>#<Pull Request number>)
+<title of Kanbanery card or summary of feature> [<Task abbreviation> #<Kanbanery task number>] (<Source Control abbreviation> #<Pull Request number>)
 
 <highlights of feature change if any>
 ```
@@ -46,7 +46,7 @@ When running the above command you will be prompted for a commit message for you
 And example would look like
 
 ```
-Return 404 on permissions API when no access [KB#1188645] (GH#4)
+Return 404 on permissions API when no access [KB #1188645] (GH #4)
 
 If a user no access to a study at all we want to be able communicate that to API clients, thus we will return a 404.
 ```


### PR DESCRIPTION
See the commit messages in https://github.com/RoleModel/fieldvault-ipad/commit/ebd1d0cf544a1ed997388eca337299a72ef239db (doesn't autolink) vs. https://github.com/RoleModel/fieldvault-ipad/commit/afa9d3563a83a68f20abac58a1cb47d21df803c8 (does auto link).

Please let me know what you guys think.
