### PR TITLE
Clarify `git rebase --onto` instructions

### DIFF
--- a/git/release-branching.md
+++ b/git/release-branching.md
@@ -154,4 +154,8 @@ o---o---o master
                 o feature
 ```
 
-If you have more than one commit unique to the feature branch, you can't use `F^` in the `rebase --onto` command. Instead, you should use `F~3` or similar, depending on how many commits you have. If you don't know the number to use, you can still determine it (assuming you haven't pushed master to origin yet) with `git log --oneline origin/master..feature`, which will list the commits in the `feature` branch and not in the `origin/master` branch. (If you have pushed already, you will have to either examine the git log and rely on your memory, or else use the revlog. Good luck, and don't be shy about asking for help!)
+If you have more than one commit unique to the feature branch, `F` should be the first (i.e. earliest) of them. If you don't know which one that is, you have a few options:
+
+* If you haven't pushed master to origin yet, then `git log --oneline origin/master..feature` will list the commits that are in the `feature` branch and not in the `origin/master` branch.
+* Or just rely on a regular `git log` and your memory.
+* If all else fails, you can use the git reflog to tell you what commit the `release` branch used to point to. If you followed these instructions, `release@(1)` will be the commit the `release` branch pointed to before it was rebased. Assuming that's true, `git log release@(1)..feature` will list the commits unique to the feature branch, which you can use to find your `F`.

--- a/git/release-branching.md
+++ b/git/release-branching.md
@@ -121,17 +121,17 @@ o---o---o master
             o feature
 ```
 
-After the **release branch** your state will look like:
+After rebasing the **release branch** your state will look like:
 
 ```
 A   B   G
 o---o---o master
-         \
-          H   I
-          o---o  release
-           \
-            C   D   F
-            o---o---o feature
+     \   \
+      \   H   I
+       \  o---o  release
+        \
+         C   D   F
+         o---o---o feature
 ```
 
 To clean up use `git rebase --onto`:
@@ -153,3 +153,5 @@ o---o---o master
                 J
                 o feature
 ```
+
+If you have more than one commit unique to the feature branch, you can't use `F^` in the `rebase --onto` command. Instead, you should use `F~3` or similar, depending on how many commits you have. If you don't know the number to use, you can still determine it (assuming you haven't pushed master to origin yet) with `git log --oneline origin/master..feature`, which will list the commits in the `feature` branch and not in the `origin/master` branch. (If you have pushed already, you will have to either examine the git log and rely on your memory, or else use the revlog. Good luck, and don't be shy about asking for help!)


### PR DESCRIPTION
1. Fix the diagram for the state after the release rebase but before the
   feature branch rebase, which was incorrectly showing the feature
   branch as including one of the rebased commits.
2. The `rebase --onto` instructions for dependent branches assumed that
   there was only one unique commit in the dependent branch. This commit
   adds a paragraph explaining what to do if there's more than one.