### PR TITLE
Replace "merge commit formatting" text with link to squashing doc

### DIFF
--- a/git/release-branching.md
+++ b/git/release-branching.md
@@ -61,14 +61,8 @@ Feature branches are created off of the release branch they will be merged
 into.  Work on a branch should be scoped to a single ticket or sub task and
 broken into logical commits.
 
-After code review is approved on a branch, it should be squashed into a single
-commit following the merge commit formatting.  This is done for a couple of
-reasons:
-
-1. Formatting as a merge commit is done as the actual merge commits will be
-   lost when the release branch is rebased on master.
-2. Squashing commits means that all the "thrashing" that happens on PR will not
-   need to be resolved when rebasing.
+After code review is approved on a branch, the commits should be squashed
+according to the [Squashing Commits](squashing.md) best practice.
 
 ## Hotfixes
 


### PR DESCRIPTION
I somehow missed this in my earlier revision pass, but this text is
talking about merge commit formatting, when we don't generally
recommend merge commits at this point. Instead, I linked to the
appropriate Squashing Commits best practice doc and removed the
redundant rationale.

@chorn or @BenEinwechter - Want to lend your :eyes: and give Caleb's a break? :smile: