### PR TITLE
Update database-migrations.md

### DIFF
--- a/rails/database-migrations.md
+++ b/rails/database-migrations.md
@@ -3,7 +3,7 @@
 ## Principles
 
 ### Use the strong_migrations library
-[Strong Migrations](https://github.com/ankane/strong_migrations) helps catch many common database migration mistakes, especially when using Postgres. Most of the checks are aimed at avoiding blocks to reads or writes. This is important for a production database with lots of data but no so much for an MVP. 
+[Strong Migrations](https://github.com/ankane/strong_migrations) helps catch many common database migration mistakes, especially when using Postgres. Most of the checks are aimed at avoiding blocks to reads or writes. This is important for a production database with lots of data but not so much for an MVP. 
 
 ### Use Rails migrations for simple data migrations
 Using Rails' `db:migrate` to migrate data has many advantages over custom scripts:

--- a/rails/database-migrations.md
+++ b/rails/database-migrations.md
@@ -3,7 +3,7 @@
 ## Principles
 
 ### Use the strong_migrations library
-https://github.com/ankane/strong_migrations helps catch many common database migration mistakes, especially when using Postgres.
+[Strong Migrations](https://github.com/ankane/strong_migrations) helps catch many common database migration mistakes, especially when using Postgres. Most of the checks are aimed at avoiding blocks to reads or writes. This is important for a production database with lots of data but no so much for an MVP. 
 
 ### Use Rails migrations for simple data migrations
 Using Rails' `db:migrate` to migrate data has many advantages over custom scripts:


### PR DESCRIPTION
We tried `strong_migrations` in a project and found some of the suggestions irritating, such as splitting a `references` migration with index into three separate migrations. It is helpful to learn more about potentially dangerous migrations, but we ended up removing the gem because of the extra work it required for little benefit.