### PR TITLE
Add recommended keybindings for AI autocomplete tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ This holds *all* of our [best practices](about.md).
 1. [Project Update Presentations](presentations/project_update.md)
 2. [Chow and Pow Wow](presentations/chow_and_pow_wow.md) (deprecated)
 3. [Core Project Presentations](presentations/core_presentation.md) (deprecated)
+
+## AI Tools
+
+1. [AI Autocomplete](ai_tools/ai_autocomplete.md)

--- a/ai_tools/ai_autocomplete.md
+++ b/ai_tools/ai_autocomplete.md
@@ -14,7 +14,7 @@ In addition, it is helpful to add a keybinding to toggle AI completions on and o
 
 These keybindings incorporate the above suggestions and address a few other conflicts between common navigation shortcuts and Copilot's default keybindings.
 
-```json
+```javascript
 [
   // Unbind the default shortcut to accept inline suggestions with tab
   {

--- a/ai_tools/ai_autocomplete.md
+++ b/ai_tools/ai_autocomplete.md
@@ -1,0 +1,57 @@
+## [Home](../README.md)
+
+# 1. AI Autocomplete
+
+AI autocomplete tools can be very helpful in the right situations, but they can also be overly aggressive and unhelpful in the wrong situations. Most tools default to using `tab` to accept suggestions, but that can often result in unintentionally accepting suggestions when trying to navigate code or change indentation.
+
+## Recommended Keybindings
+
+Using `;` to accept suggestions (or another key that is easy to reach and not typed often) significantly improves the experience of using AI autocomplete tools.
+
+In addition, it is helpful to add a keybinding to toggle AI completions on and off. Then if the suggestions are particularly unhelpful, such as when writing comments, they can be temporarily disabled.
+
+### Settings for GitHub Copilot in Visual Studio Code
+
+These keybindings incorporate the above suggestions and address a few other conflicts between common navigation shortcuts and Copilot's default keybindings.
+
+```json
+[
+  // Unbind the default shortcut to accept inline suggestions with tab
+  {
+    "key": "tab",
+    "command": "-editor.action.inlineSuggest.commit"
+  },
+
+  // Unbind the default "accept next word" shortcut because it interferes with
+  // a common macOS navigation shortcut.
+  {
+    "key": "cmd+right",
+    "command": "-editor.action.inlineSuggest.acceptNextWord",
+  },
+
+  // Recommended "accept full suggestion" shortcut. Pick a different key if you
+  // often need to type semicolons.
+  {
+    "key": ";",
+    "command": "editor.action.inlineSuggest.commit",
+    "when": "inlineEditIsVisible && inlineSuggestionVisible && !editorHoverFocused"
+  },
+
+  // Suggested keyboard shortcuts to accept part of a suggestion
+  {
+    "key": "ctrl+shift+;",
+    "command": "editor.action.inlineSuggest.acceptNextLine"
+  },
+  {
+    "key": "ctrl+;",
+    "command": "editor.action.inlineSuggest.acceptNextWord",
+    "when": "inlineSuggestionVisible && !editorReadonly"
+  },
+
+  // Recommended shortcut to toggle inline completions
+  {
+    "key": "cmd+k cmd+a",
+    "command": "github.copilot.completions.toggle"
+  }
+]
+```


### PR DESCRIPTION
This adds a section for AI tools, with the assumption that we will expand that with further recommendations as we learn what works well and what does not. For now, I've added a document for AI code autocomplete with recommendations for adjustments to default keybindings.