### PR TITLE
Update Copilot shortcut to snooze instead of toggle

### DIFF
--- a/ai_tools/ai_autocomplete.md
+++ b/ai_tools/ai_autocomplete.md
@@ -48,10 +48,12 @@ These keybindings incorporate the above suggestions and address a few other conf
     "when": "inlineSuggestionVisible && !editorReadonly"
   },
 
-  // Recommended shortcut to toggle inline completions
+  // Recommended shortcut to temporarily pause inline completions.
+  // This will prompt to select a duration to snooze suggestions.
   {
     "key": "cmd+k cmd+a",
-    "command": "github.copilot.completions.toggle"
+    "command": "editor.action.inlineSuggest.snooze",
+    "when": "editorFocus",
   }
 ]
 ```


### PR DESCRIPTION
Since these recommendations were created, Copilot gained a new feature that lets you snooze notifications for a few minutes. I think this is better than fully toggling completions off, because then you don't have to remember to turn completions back on later.